### PR TITLE
Change the cipa_features member from last_states to repol_states

### DIFF
--- a/src/types/cipa_features.cpp
+++ b/src/types/cipa_features.cpp
@@ -54,8 +54,8 @@ void Cipa_Features::copy(const Cipa_Features &source)
   vm_data.insert( (source.vm_data).begin(), (source.vm_data).end() );
   cai_data.clear();
   cai_data.insert( (source.cai_data).begin(), (source.cai_data).end() );
-  last_states.clear();
-  last_states.insert( last_states.end(), (source.last_states).begin(), (source.last_states).end() );
+  repol_states.clear();
+  repol_states.insert( repol_states.end(), (source.repol_states).begin(), (source.repol_states).end() );
 }
 
 void Cipa_Features::init(const double vm_val, const double ca_val)
@@ -89,5 +89,5 @@ void Cipa_Features::init(const double vm_val, const double ca_val)
   time_series_data.clear();
   vm_data.clear();
   cai_data.clear();
-  last_states.clear();
+  repol_states.clear();
 }

--- a/src/types/cipa_features.hpp
+++ b/src/types/cipa_features.hpp
@@ -41,7 +41,7 @@ struct Cipa_Features{
   multimap<double, string> time_series_data;
   multimap<double, double> vm_data;
   multimap<double, double> cai_data;
-  vector<double> last_states;
+  vector<double> repol_states;
 
   Cipa_Features();
   Cipa_Features( const Cipa_Features &source );


### PR DESCRIPTION
To avoid the confusing name, we renamed one of the member of cipa_features struct from last_states into repol_states. repol_states represents the vector that will stores the value of all states variables at the highest dVM/dt at the repolarisation phase.