### PR TITLE
Change the cell_name and celltype into cell_model variable

### DIFF
--- a/src/functions/inputoutput.cpp
+++ b/src/functions/inputoutput.cpp
@@ -168,8 +168,8 @@ int assign_params(int *argc, char *argv[], Parameter *p_param)
   // and store each line to the buffer
   while ( is_default == false && fgets( buffer, 100, fp_inputdeck ) != NULL ) {
     sscanf( buffer, "%s %*s %s", key, value );
-    if (strcasecmp(key, "celltype") == 0) {
-      p_param->celltype = strtol( value, NULL, 10 );
+    if (strcasecmp(key, "cell_model") == 0) {
+      strncpy( p_param->cell_model, value, sizeof(p_param->cell_model) );
     }
     else if (strcasecmp(key, "solver_type") == 0) {
       p_param->solver_type = strtol( value, NULL, 10 );
@@ -213,8 +213,8 @@ int assign_params(int *argc, char *argv[], Parameter *p_param)
     else if (strcasecmp(key, "drug_name") == 0) {
       strncpy( p_param->drug_name, value, sizeof(p_param->concs) );
     }
-    else if (strcasecmp(key, "cell_name") == 0) {
-      strncpy( p_param->cell_name, value, sizeof(p_param->cell_name) );
+    else if (strcasecmp(key, "cell_model") == 0) {
+      strncpy( p_param->cell_model, value, sizeof(p_param->cell_model) );
     }
     else if (strcasecmp(key, "concentrations") == 0) {
       strncpy( p_param->concs, value, sizeof(p_param->concs) );

--- a/src/types/cml_consts.hpp
+++ b/src/types/cml_consts.hpp
@@ -34,12 +34,19 @@ namespace cml{
     // master node that usually used in the MPI program
     static const int MASTER_NODE = 0;
     static const std::unordered_map<std::string, std::string> MAP_CELL_NAME = {
-        {"ordstatic", "O'Hara-Rudy (ORd) (2011)"},
-        {"ord", "O'Hara-Rudy IKr-dynamic (2017)"},
-        {"tomek", "Tomek et al. (ToR-ORd) (2019)"},
-        {"tomekdyncl","Tomek Cl-dynamic  (ToR-ORd-dynCl) (2020) "}
+        {"ORdstatic-Dutta_endo", "O'Hara-Rudy with Dutta Modification (2011) endocardium"},
+        {"ORdstatic-Dutta_epi", "O'Hara-Rudy with Dutta Modification (2011) epicardium"},
+        {"ORdstatic-Dutta_myo", "O'Hara-Rudy with Dutta Modification (2011) mid-myocardium"},
+        {"CiPAORdv1.0_endo", "O'Hara-Rudy IKr-dynamic (2017) endocardium"},
+        {"CiPAORdv1.0_epi", "O'Hara-Rudy IKr-dynamic (2017) epicardium"},
+        {"CiPAORdv1.0_myo", "O'Hara-Rudy IKr-dynamic (2017) mid-myocardium"},
+        {"ToR-ORd_endo", "Tomek et al. (2019) endocardium"},
+        {"ToR-ORd_epi", "Tomek et al. (2019) epicardium"},
+        {"ToR-ORd_myo", "Tomek et al. (2019) mid-myocardium"},
+        {"ToR-ORd-dynCl_endo","Tomek model with dynamic chloride (2020) endocardium"},
+        {"ToR-ORd-dynCl_epi","Tomek model with dynamic chloride (2020) epicardium"},
+        {"ToR-ORd-dynCl_myo","Tomek model with dynamic chloride (2020) mid-myocardium"}
     };
-    static const std::vector<std::string> VECTOR_CELL_TYPE = {"endocardium", "epicardium", "mid-myocardium"};
   }
 
   namespace network{

--- a/src/types/parameter.cpp
+++ b/src/types/parameter.cpp
@@ -8,7 +8,6 @@ void Parameter::init()
 {
   bcl = 2000.;
   pace_max = 1000;
-  celltype = 0;
   solver_type = 0;
   dt = 0.005;
   dt_min = 0.005;
@@ -36,11 +35,11 @@ void Parameter::init()
   cl_decrement = 10;
   cl_end = 100;
   rest_pace_max = 20;
+  snprintf(cell_model, sizeof(cell_model), "%s", "CiPAORdv1.0_endo");
   snprintf(mutation_type, sizeof(mutation_type), "%s", "CTL");
   snprintf(user_name, sizeof(user_name), "%s", "johndoe");
   snprintf(hill_file, sizeof(hill_file), "%s", "./chantest_hill/bepridil/IC50_samples10.csv");
   snprintf(herg_file, sizeof(herg_file), "%s", "./chantest_herg/bepridil/boot_pars10.csv");
-  snprintf(cell_name, sizeof(cell_name), "%s", "ordstatic");
 // CVAR
   snprintf(cvar_file, sizeof(cvar_file), "%s", "./population/control.csv");
   snprintf(drug_name, sizeof(drug_name), "%s", "bepridil");
@@ -91,7 +90,6 @@ void Parameter::show_val()
   mpi_printf( 0, "%s -- %s\n", "is_cvar", is_cvar ? "true" : "false" );
   mpi_printf( 0, "%s -- %s\n", "cvar_file", cvar_file );
   mpi_printf( 0, "%s -- %s\n", "repol_states_folder", repol_states_folder);
-  mpi_printf( 0, "%s -- %hd\n", "celltype", celltype);
   mpi_printf( 0, "%s -- %hd\n", "solver_type", solver_type);
   mpi_printf( 0, "%s -- %s\n", "is_postprocessing", is_postprocessing ? "true" : "false" );
   mpi_printf( 0, "%s -- %lf\n", "basic_cycle_length", bcl);
@@ -122,7 +120,7 @@ void Parameter::show_val()
   mpi_printf( 0, "%s -- %lf\n", "tau_h_scale", tau_h_scale);
   mpi_printf( 0, "%s -- %s\n", "mutation_type", mutation_type);
   mpi_printf( 0, "%s -- %s\n", "drug_name", drug_name);
-  mpi_printf( 0, "%s -- %s\n", "cell_name", cell_name);
+  mpi_printf( 0, "%s -- %s\n", "cell_model", cell_model);
   mpi_printf( 0, "%s -- %hd\n", "prior_risk", prior_risk);
   mpi_printf( 0, "%s -- %s\n", "concentrations", concs);
 #ifdef TISSUE

--- a/src/types/parameter.hpp
+++ b/src/types/parameter.hpp
@@ -6,7 +6,7 @@ struct Parameter
   double bcl; // basic cycle length
   short pace_max; // maximum pace
   short solver_type; // 0: Euler, 1: CVode, 2: Analytical, 3: BDF
-  short celltype;  // 0: endo, 1: epi, 2: M
+  char cell_model[50]; // cell model type and the type of the cell (if exist)
   short prior_risk; // 0: low, 1: intermediate, 2: high
   double dt;        // time step
   double dt_min;    // minimum time step (for adaptive dt)
@@ -39,7 +39,6 @@ struct Parameter
   char drug_name[100];
   char concs[50];
   char user_name[20];
-  char cell_name[20];
   char repol_states_folder[100];
   // restitution protocol
   double cl_decrement;


### PR DESCRIPTION
- replace the cell_name and celltype into a new variable named cell_model
- cell_model name uses the official name of the cell model from paper and includes the celltypes, separated by underscore ("_")
- cell_type consists of endo, epi, and myo.
- exisiting cell_model values (from this pull request):

    (before, it was ord)
    - CiPAORdv1.0_endo
    - CiPAORdv1.0_epi
    - CiPAORdv1.0_myo
    (before, it was ordstatic)  
    - ORdstatic-Dutta_endo
    - ORdstatic-Dutta_epi
    - ORdstatic-Dutta_myo
    (before, it was tomek)
    - ToR-ORd_endo
    - ToR-ORd_epi
    - ToR-ORd_myo
    (before, it was tomek_dyncl)
    - ToR-ORd-dynCl_endo
    - ToR-ORd-dynCl_epi
    - ToR-ORd-dynCl_myo
