### PR TITLE
Rename repol_states into initial_values in the Cipa_Features structures

### DIFF
--- a/src/functions/inputoutput.hpp
+++ b/src/functions/inputoutput.hpp
@@ -42,6 +42,6 @@ int check_drug_data_content(const Drug_Block_Input &vec, const Parameter *p_para
 int assign_params(int *argc, char **argv, Parameter *p_param);
 
 // create concentration directories
-int create_concs_directories( std::vector<double> &concs, const char *drug_name );
+int create_drug_concentrations_directories( std::vector<double> &concs, const char *drug_name );
 
 #endif

--- a/src/types/cipa_features.cpp
+++ b/src/types/cipa_features.cpp
@@ -54,8 +54,8 @@ void Cipa_Features::copy(const Cipa_Features &source)
   vm_data.insert( (source.vm_data).begin(), (source.vm_data).end() );
   cai_data.clear();
   cai_data.insert( (source.cai_data).begin(), (source.cai_data).end() );
-  repol_states.clear();
-  repol_states.insert( repol_states.end(), (source.repol_states).begin(), (source.repol_states).end() );
+  initial_values.clear();
+  initial_values.insert( initial_values.end(), (source.initial_values).begin(), (source.initial_values).end() );
 }
 
 void Cipa_Features::init(const double vm_val, const double ca_val)
@@ -89,5 +89,5 @@ void Cipa_Features::init(const double vm_val, const double ca_val)
   time_series_data.clear();
   vm_data.clear();
   cai_data.clear();
-  repol_states.clear();
+  initial_values.clear();
 }

--- a/src/types/cipa_features.hpp
+++ b/src/types/cipa_features.hpp
@@ -41,7 +41,7 @@ struct Cipa_Features{
   multimap<double, string> time_series_data;
   multimap<double, double> vm_data;
   multimap<double, double> cai_data;
-  vector<double> repol_states;
+  vector<double> initial_values;
 
   Cipa_Features();
   Cipa_Features( const Cipa_Features &source );


### PR DESCRIPTION
-Change the name of repol_states into initial_values in the Cipa_Features.
-minor detail change in the inputoutput function