### PR TITLE
Adding number of CPU check to override error in inputoutput function

### DIFF
--- a/src/functions/inputoutput.cpp
+++ b/src/functions/inputoutput.cpp
@@ -276,6 +276,11 @@ int assign_params(int *argc, char *argv[], Parameter *p_param)
     else if (strcasecmp(key, "stimulus_amplitude_scale") == 0) {
       p_param->stimulus_amplitude_scale = strtod( value, NULL);
     }
+    else if (strcasecmp(key, "number_of_cpu") == 0) {
+      // let it empty since cpu_number used during mpiexec call.
+      // adding this only to override the error message.
+    }
+
 #ifdef TISSUE
     else if (strcasecmp(key, "diffusion_scale") == 0) {
       p_param->diffusion_scale = strtod( value, NULL);


### PR DESCRIPTION
- Adding the number_of_cpu input in the inputoutput function
- The addition of the conditional is to prevent the error message popped up for this option
- The number_of_cpu will be used for the argument of mpiexec, not as the part of the simulation code. Hence the reason why I didn't specify anything there.