### PR TITLE
Revise initial value parameter from folder path into zip files

### DIFF
--- a/src/functions/inputoutput.cpp
+++ b/src/functions/inputoutput.cpp
@@ -261,8 +261,8 @@ int assign_params(int *argc, char *argv[], Parameter *p_param)
     else if (strcasecmp(key, "mutation_type") == 0){
       strncpy( p_param->mutation_type, value, sizeof(p_param->mutation_type));
     }
-    else if (strcasecmp(key, "initial_values_directory") == 0 && strlen(value) > 0){
-      strncpy( p_param->initial_values_directory, value, sizeof(p_param->initial_values_directory));
+    else if (strcasecmp(key, "initial_values_zip_file") == 0 && strlen(value) > 0){
+      strncpy( p_param->initial_values_zip_file, value, sizeof(p_param->initial_values_zip_file));
     }
     else if (strcasecmp(key, "is_postprocessing") == 0){
       p_param->is_postprocessing = strtol( value, NULL, 10 );
@@ -326,24 +326,6 @@ int assign_params(int *argc, char *argv[], Parameter *p_param)
   return 0;
 }
 
-int create_drug_concentrations_directories( std::vector<double> &drug_concentrations, const char *drug_name )
+int create_drug_concentrations_directories( std::vector<double> &drug_concentrations, const Parameter *p_param)
 {
-  // constants to avoid magic values
-  static const double CONTROL_CONC = 0.;
-  char buffer[900];
-  char create_time_str[9];
-  int idx;
-
-  make_directory(cml::commons::RESULT_FOLDER);
-  snprintf( buffer, sizeof(buffer), "%s/%s", cml::commons::RESULT_FOLDER, drug_name);
-  if(is_file_existed(cml::commons::RESULT_FOLDER) == 0) make_directory(buffer);
-  snprintf( buffer, sizeof(buffer), "%s/%s/%.2lf", cml::commons::RESULT_FOLDER, drug_name, CONTROL_CONC);
-  if(is_file_existed(cml::commons::RESULT_FOLDER) == 0) make_directory(buffer);
-  for( idx = 0; idx < drug_concentrations.size(); idx++ )
-  { // begin concentration loop
-    snprintf( buffer, sizeof(buffer), "%s/%s/%.2lf", cml::commons::RESULT_FOLDER, drug_name, drug_concentrations[idx] );
-    if(is_file_existed(cml::commons::RESULT_FOLDER) == 0) make_directory(buffer);
-  } // end concentration loop
-
-  return 0;
 }

--- a/src/functions/inputoutput.hpp
+++ b/src/functions/inputoutput.hpp
@@ -42,6 +42,6 @@ int check_drug_data_content(const Drug_Block_Input &vec, const Parameter *p_para
 int assign_params(int *argc, char **argv, Parameter *p_param);
 
 // create concentration directories
-int create_drug_concentrations_directories( std::vector<double> &concs, const char *drug_name );
+int create_drug_concentrations_directories( std::vector<double> &concs, const Parameter *p_param );
 
 #endif

--- a/src/types/parameter.cpp
+++ b/src/types/parameter.cpp
@@ -41,7 +41,7 @@ void Parameter::init()
 // CVAR
   snprintf(cvar_file, sizeof(cvar_file), "%s", "./population/control.csv");
   snprintf(drug_name, sizeof(drug_name), "%s", "bepridil");
-  snprintf(initial_values_directory, sizeof(initial_values_directory), "../simulation_cpu/results/bepridil");
+  snprintf(initial_values_zip_file, sizeof(initial_values_zip_file), "bepridil_CiPAORdv1.0_endo_initial_values.zip");
   snprintf(drug_concentrations, sizeof(drug_concentrations), "%s", "99.0");
 
 #ifdef TISSUE
@@ -87,7 +87,7 @@ void Parameter::show_val()
   mpi_printf( 0, "%s -- %s\n", "herg_file", herg_file );
   mpi_printf( 0, "%s -- %s\n", "is_cvar", is_cvar ? "true" : "false" );
   mpi_printf( 0, "%s -- %s\n", "cvar_file", cvar_file );
-  mpi_printf( 0, "%s -- %s\n", "initial_values_directory", initial_values_directory);
+  mpi_printf( 0, "%s -- %s\n", "initial_values_zip_file", initial_values_zip_file);
   mpi_printf( 0, "%s -- %s\n", "solver_type", solver_type);
   mpi_printf( 0, "%s -- %s\n", "is_postprocessing", is_postprocessing ? "true" : "false" );
   mpi_printf( 0, "%s -- %lf\n", "cycle_length", cycle_length);

--- a/src/types/parameter.hpp
+++ b/src/types/parameter.hpp
@@ -37,7 +37,7 @@ struct Parameter
   char drug_name[100];
   char drug_concentrations[50];
   char user_name[20];
-  char initial_values_directory[100];
+  char initial_values_zip_file[100];
   // restitution protocol
   double cl_decrement;
   double cl_end;


### PR DESCRIPTION
- Remove the content of the create_drug_concentrations_directories() function since it would be moved into a BaSH script for the ease of development.
- Change the parameter of initial_values_directory into initial_values_zip_file. Will be used in the postprocessing module.