### PR TITLE
Revise the locking system by only using Machine-UUID

### DIFF
--- a/src/functions/softdongle.cpp
+++ b/src/functions/softdongle.cpp
@@ -157,7 +157,7 @@ std::string get_system_uuid() {
 
 std::string get_hardware_id()
 {
-  return get_machine_uuid() + "==" + get_system_uuid();
+  return get_machine_uuid();
 }
 
 int validate_license()


### PR DESCRIPTION
- Only to make sure the locking code is only from machine id. System UUID always reset the ownership of the file, hence not good for checking it